### PR TITLE
Use the configured group for 'make install'

### DIFF
--- a/internal/make/make.go
+++ b/internal/make/make.go
@@ -160,7 +160,7 @@ func installExe(cfg Config, exe, dir, caps string) {
 	defer dst.Close()
 	_, err = io.Copy(dst, src)
 	chkfatal(err)
-	chkfatal(os.Chown(dstPath, 0, getGid("sandstorm")))
+	chkfatal(os.Chown(dstPath, 0, getGid(cfg.Group)))
 	if caps != "" {
 		chkfatal(withMyOuts(exec.Command("setcap", caps, dstPath)).Run())
 	}


### PR DESCRIPTION
I was testing Tempest for the first time and tried a make install after having set the group (via ./configure) to "tempest".  When I saw the error that the "sandstorm" group didn't exist, I found this bug.