### PR TITLE
Make SMTP configuration optional

### DIFF
--- a/internal/server/main/config.go
+++ b/internal/server/main/config.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/smtp"
 	"net/url"
+	"os"
 	"strconv"
 
 	"golang.org/x/exp/slog"
@@ -51,12 +52,21 @@ func (c SMTPConfig) SendMail(to []string, msg []byte) error {
 	)
 }
 
-func SMTPConfigFromSettings(src settings.Source) SMTPConfig {
+func SMTPConfigFromSettings(src settings.Source) (cfg SMTPConfig) {
+	sh := src.GetString("SMTP_HOST")
+	sprt := os.Getenv("SMTP_PORT")
+	su := src.GetString("SMTP_USERNAME")
+	sp := src.GetString("SMTP_PASSWORD")
+
+	if sh == "" || sprt == "" || su == "" || sp == "" {
+		return
+	}
+
 	return SMTPConfig{
-		Host:     src.GetString("SMTP_HOST"),
+		Host:     sh,
 		Port:     strconv.Itoa(int(src.GetUint16("SMTP_PORT"))),
-		Username: src.GetString("SMTP_USERNAME"),
-		Password: src.GetString("SMTP_PASSWORD"),
+		Username: su,
+		Password: sp,
 	}
 }
 

--- a/internal/server/main/config.go
+++ b/internal/server/main/config.go
@@ -58,16 +58,16 @@ func SMTPConfigFromSettings(src settings.Source) (cfg SMTPConfig) {
 	su := src.GetString("SMTP_USERNAME")
 	sp := src.GetString("SMTP_PASSWORD")
 
-	if sh == "" || sprt == "" || su == "" || sp == "" {
+	if sh == "" || sprt == "" {
 		return
 	}
 
-	return SMTPConfig{
-		Host:     sh,
-		Port:     strconv.Itoa(int(src.GetUint16("SMTP_PORT"))),
-		Username: su,
-		Password: sp,
-	}
+	cfg.Host = sh
+	cfg.Port = strconv.Itoa(int(src.GetUint16("SMTP_PORT")))
+	cfg.Username = su
+	cfg.Password = sp
+
+	return
 }
 
 func HTTPConfigFromSettings(lg *slog.Logger, src settings.Source) HTTPConfig {


### PR DESCRIPTION
From the README.md, it's sensible to surmise that SMTP configuration is optional, e.g.

> Out of the box, it is possible to login in via both email (if the SMTP_* enviornment variables are set)

However, leaving `SMTP_PORT` empty results in a parsing error: `panic: strconv.ParseUint: parsing "": invalid syntax`

This PR makes it optional to initialize SMTP_* for startup/bootstrapping.

Since these variables have not been optional in the past, it's unknown what the downstream effect of this PR may be, and as such, it may not be appropriate in its current form. It's probable that any email-sending code needs to check whether the SMTP configuration is fully initialized before attempting to send.
